### PR TITLE
Update Cargo.toml for sawtooth_sdk

### DIFF
--- a/src/core/Cargo.toml
+++ b/src/core/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 authors = ["Intel Corporation"]
 
 [dependencies]
-sawtooth_sdk = { path = "../../../sawtooth-core/sdk/rust" }
+sawtooth_sdk = { git = "https://github.com/hyperledger/sawtooth-core.git" }
 rand = "0.4.2"
 log = "0.3.0"
 log4rs = "0.7.0"


### PR DESCRIPTION
Update Cargo.toml to fix sawtooth_sdk reference. Move
from local reference to git reference.

Signed-off-by: rranjan3 <rajeev2.ranjan@intel.com>