### PR TITLE
Unit Tests error fix

### DIFF
--- a/src/core/src/database/lmdb.rs
+++ b/src/core/src/database/lmdb.rs
@@ -255,7 +255,7 @@ impl<'a> LmdbDatabaseWriter<'a> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use config;
+    use database::config;
 
     /// Asserts that there are COUNT many objects in DB.
     fn assert_database_count(count: usize, db: &LmdbDatabase) {

--- a/src/core/src/service.rs
+++ b/src/core/src/service.rs
@@ -321,6 +321,8 @@ pub fn get_wait_cert_and_signature(block: &Block) -> (String, String) {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use rand;
+    use rand::Rng;
     use std::default::Default;
     use zmq;
     use sawtooth_sdk::consensus::{zmq_service::ZmqService};

--- a/unit-poet2.yaml
+++ b/unit-poet2.yaml
@@ -21,7 +21,7 @@ services:
     container_name: poet2-test
     build:
       context: ./
-      dockerfile: ./poet2-engine.dockerfile
+      dockerfile: ./poet2-sgx-engine.dockerfile
       args:
         - http_proxy
         - https_proxy


### PR DESCRIPTION
This PR fixes Unit Test errors.
Unit tests are run using "docker-compose -f unit-poet2.yaml up"
Several errors were reported by cargo.
This PR fixes the errors thereby enabling UT to be run.

Signed-off-by: mithunshashidhara <mithunx.shashidhara@intel.com>