### PR TITLE
Fix sdk to a revision

### DIFF
--- a/src/core/Cargo.toml
+++ b/src/core/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 authors = ["Intel Corporation"]
 
 [dependencies]
-sawtooth_sdk = { git = "https://github.com/hyperledger/sawtooth-core.git", branch = "master" }
+sawtooth_sdk = { git = "https://github.com/hyperledger/sawtooth-core.git", rev="7ac644d" }
 rand = "0.4.2"
 log = "0.4.5"
 log4rs = "0.8.1"


### PR DESCRIPTION
Fix sdk revision. Address changes for sdk in a single go at later stage. 
Addressing as and when changes arrive is disruptive.

Signed-off-by: Rajeev Ranjan <rajeev2.ranjan@intel.com>